### PR TITLE
Add distill command CLI with --dry-run, --force, --push-to-oh, --context-id options

### DIFF
--- a/src/distill.rs
+++ b/src/distill.rs
@@ -1,0 +1,108 @@
+//! Distill command - batch extraction from all sessions
+//!
+//! Replaces per-turn extraction with on-demand batch distillation.
+//! Processes all sessions in ~/.claude/projects/<project-id>/ and extracts
+//! tacit knowledge in two passes:
+//! - Pass 1: Extract knowledge from each session (yz-fsws)
+//! - Pass 2: Categorize into guardrails vs metis (yz-u164)
+//!
+//! AIDEV-NOTE: This is the CLI scaffold. Actual extraction logic will be
+//! implemented in yz-fsws (blocked by this task).
+
+use crate::session::{self, SessionInfo};
+use crate::state;
+
+/// Options for the distill command
+pub struct DistillOptions {
+    /// Preview what would be extracted without writing
+    pub dry_run: bool,
+
+    /// Force re-extraction even for already-processed sessions
+    pub force: bool,
+
+    /// Push distilled knowledge to Open Horizons via MCP
+    pub push_to_oh: bool,
+
+    /// OH context ID to push to (required if push_to_oh is true)
+    pub context_id: Option<String>,
+}
+
+/// Run the distill command
+pub fn run(options: DistillOptions) -> Result<(), String> {
+    if !state::is_initialized() {
+        return Err("Not initialized. Run 'wm init' first.".to_string());
+    }
+
+    // Validate options
+    if options.push_to_oh && options.context_id.is_none() {
+        return Err("--context-id is required when using --push-to-oh".to_string());
+    }
+
+    // Discover all sessions for this project
+    let project_path = session::current_project_path();
+    let sessions = session::discover_sessions(&project_path)?;
+
+    if sessions.is_empty() {
+        println!("No sessions found for project.");
+        return Ok(());
+    }
+
+    println!("Found {} session(s)", sessions.len());
+
+    if options.dry_run {
+        println!("\n[DRY RUN] Would process:");
+        for session in &sessions {
+            print_session_info(session);
+        }
+        return Ok(());
+    }
+
+    // TODO(yz-fsws): Implement Pass 1 - batch extraction from all sessions
+    // For each session:
+    //   1. Check if already processed (unless --force)
+    //   2. Read transcript
+    //   3. Extract tacit knowledge
+    //   4. Accumulate results
+
+    // TODO(yz-u164): Implement Pass 2 - categorize into guardrails vs metis
+    // For accumulated knowledge:
+    //   1. Classify each item
+    //   2. Write to .wm/distilled/guardrails.md and .wm/distilled/metis.md
+
+    // TODO(yz-pltc): Implement OH integration
+    // If --push-to-oh:
+    //   1. Call OH MCP to create guardrail/metis candidates
+    //   2. Report what was pushed
+    // AIDEV-NOTE: OH push will use direct HTTP calls to OH API (not MCP) since wm
+    // runs outside Claude Code's MCP context. Requires OH_API_KEY env var.
+
+    println!("\nDistillation not yet implemented.");
+    println!("Sessions to process:");
+    for session in &sessions {
+        print_session_info(session);
+    }
+
+    if options.force {
+        println!("\n[--force] Would re-extract all sessions regardless of prior processing.");
+    }
+
+    if options.push_to_oh {
+        println!(
+            "\n[--push-to-oh] Would push to OH context: {}",
+            options.context_id.as_deref().unwrap_or("(none)")
+        );
+    }
+
+    Ok(())
+}
+
+/// Print session info for display
+fn print_session_info(session: &SessionInfo) {
+    let size_kb = session.size_bytes / 1024;
+    println!(
+        "  {} ({} KB, modified {})",
+        session.session_id,
+        size_kb,
+        session.modified_at.format("%Y-%m-%d %H:%M")
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::process::ExitCode;
 
 mod compile;
 mod compress;
+mod distill;
 mod extract;
 mod init;
 mod session;
@@ -45,6 +46,25 @@ enum Commands {
 
     /// Compress state.md by synthesizing to higher-level abstractions
     Compress,
+
+    /// Batch extract knowledge from all sessions (replaces per-turn extract)
+    Distill {
+        /// Preview what would be extracted without writing
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Force re-extraction even for already-processed sessions
+        #[arg(long)]
+        force: bool,
+
+        /// Push distilled knowledge to Open Horizons via MCP
+        #[arg(long)]
+        push_to_oh: bool,
+
+        /// OH context ID to push to (required if --push-to-oh is set)
+        #[arg(long)]
+        context_id: Option<String>,
+    },
 
     /// Display state, working set, or sessions
     Show {
@@ -108,6 +128,17 @@ fn main() -> ExitCode {
         } => extract::run(transcript, session_id),
         Commands::Compile { intent } => compile::run(intent),
         Commands::Compress => compress::run(),
+        Commands::Distill {
+            dry_run,
+            force,
+            push_to_oh,
+            context_id,
+        } => distill::run(distill::DistillOptions {
+            dry_run,
+            force,
+            push_to_oh,
+            context_id,
+        }),
         Commands::Show { what, session_id } => show::run(&what, session_id.as_deref()),
         Commands::Pause { operation } => run_pause(operation),
         Commands::Resume { operation } => run_resume(operation),


### PR DESCRIPTION
## Summary
- Add `wm distill` command CLI scaffold for batch knowledge extraction
- Options: `--dry-run`, `--force`, `--push-to-oh`, `--context-id`
- Session discovery already implemented (yz-xzjx)
- Actual extraction logic blocked on this task (yz-fsws, yz-u164)

## Completed Tasks
- yz-yb9q: Add distill command CLI with options

## Test plan
- [x] `cargo build` compiles without errors
- [x] `cargo test` passes all tests
- [x] `wm distill --help` shows options
- [x] `wm distill --dry-run` lists sessions
- [x] `wm distill --push-to-oh` without `--context-id` returns validation error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `distill` command for batch distillation across all project sessions
  * Includes `--dry-run` option to preview processing without execution
  * Includes `--force` option for forced processing
  * Includes `--push-to-oh` option with optional context ID parameter for contextual integration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->