### PR TITLE
feat: add named dive preps (like git branches)

### DIFF
--- a/plugin/agents/dive-prep.md
+++ b/plugin/agents/dive-prep.md
@@ -11,6 +11,26 @@ Compile a session grounding manifest from available context sources, keyed by in
 - ✅ **Claude Code** - Full support
 - ✅ **Codex** - Full support (platform-independent context gathering)
 
+## Named Dive Preps
+
+WM supports multiple named dive preps (like git branches). Use the CLI to manage them:
+
+```bash
+wm dive list              # List all preps (* marks current)
+wm dive new <name>        # Create new prep
+wm dive switch <name>     # Switch to a prep
+wm dive delete <name>     # Delete a prep
+wm dive save <name>       # Save current dive_context.md as named prep
+wm dive current           # Show current prep name
+wm dive show [name]       # Show prep content
+```
+
+When `/dive-prep` creates a manifest, you can save it as a named prep:
+1. Run `/dive-prep` to generate context
+2. Run `wm dive save my-feature` to save and activate it
+
+Named preps are stored in `.wm/dives/{name}.md` and the current prep is tracked in `config.toml`.
+
 ## Invocation
 
 `/dive-prep [--intent <type>] [options]`

--- a/src/dive.rs
+++ b/src/dive.rs
@@ -1,11 +1,215 @@
-//! Dive pack integration with Open Horizons
+//! Dive prep management - named dive contexts for session grounding
 //!
-//! Fetches curated grounding context from OH dive packs and writes to dive_context.md
+//! Supports multiple named preps (like git branches) stored in .wm/dives/
+//! with a "current" prep tracked in config.
 
 use crate::state;
+use std::fs;
 
-/// Load a dive pack from OH and write to dive_context.md
-pub fn load(pack_id: &str) -> Result<(), String> {
+// ============================================================================
+// Named prep management
+// ============================================================================
+
+/// List all dive preps, marking the current one
+pub fn list() -> Result<(), String> {
+    if !state::is_initialized() {
+        return Err("Not initialized. Run 'wm init' first.".to_string());
+    }
+
+    let preps = state::list_dive_preps().map_err(|e| format!("Failed to list preps: {}", e))?;
+    let current = state::current_dive();
+
+    if preps.is_empty() {
+        println!("No dive preps found. Create one with 'wm dive new <name>'");
+        return Ok(());
+    }
+
+    for prep in preps {
+        let marker = if current.as_ref() == Some(&prep) {
+            "* "
+        } else {
+            "  "
+        };
+        println!("{}{}", marker, prep);
+    }
+
+    Ok(())
+}
+
+/// Create a new named dive prep
+pub fn new(name: &str, content: Option<&str>) -> Result<(), String> {
+    if !state::is_initialized() {
+        return Err("Not initialized. Run 'wm init' first.".to_string());
+    }
+
+    // Validate name (kebab-case, no special chars)
+    if !is_valid_prep_name(name) {
+        return Err(format!(
+            "Invalid prep name '{}'. Use lowercase letters, numbers, and hyphens only.",
+            name
+        ));
+    }
+
+    let path = state::dive_prep_path(name);
+    if path.exists() {
+        return Err(format!("Prep '{}' already exists. Use 'wm dive switch {}' to activate it.", name, name));
+    }
+
+    state::ensure_dive_dir().map_err(|e| format!("Failed to create dives directory: {}", e))?;
+
+    let default_content = format!("# Dive: {}\n\nIntent: \n\n## Focus\n\n## Constraints\n", name);
+    let initial_content = content.unwrap_or(&default_content);
+    fs::write(&path, initial_content).map_err(|e| format!("Failed to create prep: {}", e))?;
+
+    println!("✓ Created dive prep '{}' at .wm/dives/{}.md", name, name);
+    println!("  Switch to it: wm dive switch {}", name);
+
+    Ok(())
+}
+
+/// Switch to a named dive prep (set as current)
+pub fn switch(name: &str) -> Result<(), String> {
+    if !state::is_initialized() {
+        return Err("Not initialized. Run 'wm init' first.".to_string());
+    }
+
+    let path = state::dive_prep_path(name);
+    if !path.exists() {
+        return Err(format!(
+            "Prep '{}' not found. Create it with 'wm dive new {}'",
+            name, name
+        ));
+    }
+
+    state::set_current_dive(Some(name))
+        .map_err(|e| format!("Failed to update config: {}", e))?;
+
+    println!("✓ Switched to dive prep '{}'", name);
+
+    Ok(())
+}
+
+/// Delete a named dive prep
+pub fn delete(name: &str) -> Result<(), String> {
+    if !state::is_initialized() {
+        return Err("Not initialized. Run 'wm init' first.".to_string());
+    }
+
+    let path = state::dive_prep_path(name);
+    if !path.exists() {
+        return Err(format!("Prep '{}' not found.", name));
+    }
+
+    fs::remove_file(&path).map_err(|e| format!("Failed to delete prep: {}", e))?;
+
+    // If this was the current prep, clear it
+    if state::current_dive().as_deref() == Some(name) {
+        state::set_current_dive(None)
+            .map_err(|e| format!("Failed to update config: {}", e))?;
+        println!("✓ Deleted dive prep '{}' (was current, now cleared)", name);
+    } else {
+        println!("✓ Deleted dive prep '{}'", name);
+    }
+
+    Ok(())
+}
+
+/// Save current dive_context.md as a named prep
+pub fn save(name: &str) -> Result<(), String> {
+    if !state::is_initialized() {
+        return Err("Not initialized. Run 'wm init' first.".to_string());
+    }
+
+    // Validate name
+    if !is_valid_prep_name(name) {
+        return Err(format!(
+            "Invalid prep name '{}'. Use lowercase letters, numbers, and hyphens only.",
+            name
+        ));
+    }
+
+    // Read from legacy location
+    let legacy_path = state::wm_path("dive_context.md");
+    let content = fs::read_to_string(&legacy_path)
+        .or_else(|_| fs::read_to_string(state::wm_path("OH_context.md")))
+        .map_err(|_| "No dive context found. Use /dive-prep to create one first.".to_string())?;
+
+    let target_path = state::dive_prep_path(name);
+    if target_path.exists() {
+        return Err(format!(
+            "Prep '{}' already exists. Delete it first or choose a different name.",
+            name
+        ));
+    }
+
+    state::ensure_dive_dir().map_err(|e| format!("Failed to create dives directory: {}", e))?;
+
+    fs::write(&target_path, &content).map_err(|e| format!("Failed to save prep: {}", e))?;
+
+    // Set as current
+    state::set_current_dive(Some(name))
+        .map_err(|e| format!("Failed to update config: {}", e))?;
+
+    println!("✓ Saved current dive context as '{}' (now active)", name);
+
+    Ok(())
+}
+
+/// Show current prep name
+pub fn current() -> Result<(), String> {
+    if !state::is_initialized() {
+        return Err("Not initialized. Run 'wm init' first.".to_string());
+    }
+
+    match state::current_dive() {
+        Some(name) => println!("{}", name),
+        None => println!("(none - using legacy dive_context.md if present)"),
+    }
+
+    Ok(())
+}
+
+/// Show dive prep content (current or specific)
+pub fn show(name: Option<&str>) -> Result<(), String> {
+    if !state::is_initialized() {
+        return Err("Not initialized. Run 'wm init' first.".to_string());
+    }
+
+    let content = match name {
+        Some(n) => {
+            // Show specific prep
+            let path = state::dive_prep_path(n);
+            fs::read_to_string(&path)
+                .map_err(|_| format!("Prep '{}' not found.", n))?
+        }
+        None => {
+            // Show current prep or legacy fallback
+            match state::current_dive() {
+                Some(current_name) => {
+                    let path = state::dive_prep_path(&current_name);
+                    fs::read_to_string(&path)
+                        .map_err(|_| format!("Current prep '{}' not found (may have been deleted).", current_name))?
+                }
+                None => {
+                    // Legacy fallback
+                    fs::read_to_string(state::wm_path("dive_context.md"))
+                        .or_else(|_| fs::read_to_string(state::wm_path("OH_context.md")))
+                        .map_err(|_| "No dive context loaded. Use 'wm dive new <name>' or /dive-prep to create one.".to_string())?
+                }
+            }
+        }
+    };
+
+    println!("{}", content);
+    Ok(())
+}
+
+// ============================================================================
+// Legacy OH integration (kept for backwards compatibility)
+// ============================================================================
+
+/// Load a dive pack from OH and optionally save as named prep
+pub fn load(pack_id: &str, save_as: Option<&str>) -> Result<(), String> {
     if !state::is_initialized() {
         return Err("Not initialized. Run 'wm init' first.".to_string());
     }
@@ -48,12 +252,34 @@ pub fn load(pack_id: &str) -> Result<(), String> {
         .and_then(|v| v.as_str())
         .ok_or_else(|| "Dive pack missing rendered_md field".to_string())?;
 
-    // Write to dive_context.md
-    let dive_context_path = state::wm_path("dive_context.md");
-    std::fs::write(&dive_context_path, rendered_md)
-        .map_err(|e| format!("Failed to write dive_context.md: {}", e))?;
+    // Save as named prep if requested, otherwise write to legacy location
+    if let Some(name) = save_as {
+        if !is_valid_prep_name(name) {
+            return Err(format!(
+                "Invalid prep name '{}'. Use lowercase letters, numbers, and hyphens only.",
+                name
+            ));
+        }
 
-    println!("✓ Dive pack loaded to .wm/dive_context.md ({} bytes)", rendered_md.len());
+        state::ensure_dive_dir().map_err(|e| format!("Failed to create dives directory: {}", e))?;
+
+        let path = state::dive_prep_path(name);
+        fs::write(&path, rendered_md).map_err(|e| format!("Failed to write dive prep: {}", e))?;
+
+        state::set_current_dive(Some(name))
+            .map_err(|e| format!("Failed to update config: {}", e))?;
+
+        println!("✓ Dive pack loaded as '{}' ({} bytes)", name, rendered_md.len());
+    } else {
+        // Legacy: write to dive_context.md
+        let dive_context_path = state::wm_path("dive_context.md");
+        fs::write(&dive_context_path, rendered_md)
+            .map_err(|e| format!("Failed to write dive_context.md: {}", e))?;
+
+        println!("✓ Dive pack loaded to .wm/dive_context.md ({} bytes)", rendered_md.len());
+        println!("  Tip: Use --name <name> to save as a named prep");
+    }
+
     Ok(())
 }
 
@@ -63,11 +289,22 @@ pub fn clear() -> Result<(), String> {
         return Err("Not initialized. Run 'wm init' first.".to_string());
     }
 
-    let dive_context_path = state::wm_path("dive_context.md");
+    // Clear current prep setting
+    let had_current = state::current_dive().is_some();
+    if had_current {
+        state::set_current_dive(None)
+            .map_err(|e| format!("Failed to update config: {}", e))?;
+    }
 
-    if dive_context_path.exists() {
-        std::fs::remove_file(&dive_context_path)
+    // Also remove legacy file if present
+    let dive_context_path = state::wm_path("dive_context.md");
+    let had_legacy = dive_context_path.exists();
+    if had_legacy {
+        fs::remove_file(&dive_context_path)
             .map_err(|e| format!("Failed to remove dive_context.md: {}", e))?;
+    }
+
+    if had_current || had_legacy {
         println!("✓ Dive context cleared");
     } else {
         println!("No dive context to clear");
@@ -76,23 +313,24 @@ pub fn clear() -> Result<(), String> {
     Ok(())
 }
 
-/// Show current dive context
-pub fn show() -> Result<(), String> {
-    if !state::is_initialized() {
-        return Err("Not initialized. Run 'wm init' first.".to_string());
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Validate prep name (kebab-case: lowercase letters, numbers, hyphens)
+fn is_valid_prep_name(name: &str) -> bool {
+    if name.is_empty() || name.len() > 64 {
+        return false;
     }
 
-    let dive_context_path = state::wm_path("dive_context.md");
-
-    if dive_context_path.exists() {
-        let content = std::fs::read_to_string(&dive_context_path)
-            .map_err(|e| format!("Failed to read dive_context.md: {}", e))?;
-        println!("{}", content);
-    } else {
-        println!("No dive context loaded. Use 'wm dive load <pack-id>' or /dive-prep to create one.");
+    // Must start with a letter
+    let first = name.chars().next().unwrap();
+    if !first.is_ascii_lowercase() {
+        return false;
     }
 
-    Ok(())
+    // Only lowercase letters, numbers, and hyphens
+    name.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
 }
 
 /// Load a config value from ~/.config/openhorizons/config.json
@@ -107,7 +345,7 @@ fn load_config_value(key: &str) -> Result<String, String> {
         return Err("Config file not found".to_string());
     }
 
-    let content = std::fs::read_to_string(&config_path)
+    let content = fs::read_to_string(&config_path)
         .map_err(|e| format!("Failed to read config: {}", e))?;
 
     let config: serde_json::Value = serde_json::from_str(&content)

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,17 +114,54 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum DiveCommands {
-    /// Load a dive pack from OH and write to OH_context.md
+    /// List all dive preps (marks current with *)
+    List,
+
+    /// Create a new named dive prep
+    New {
+        /// Name for the dive prep (kebab-case)
+        name: String,
+    },
+
+    /// Switch to a named dive prep
+    Switch {
+        /// Name of the prep to switch to
+        name: String,
+    },
+
+    /// Delete a named dive prep
+    Delete {
+        /// Name of the prep to delete
+        name: String,
+    },
+
+    /// Save current dive_context.md as a named prep
+    Save {
+        /// Name to save as (kebab-case)
+        name: String,
+    },
+
+    /// Show current dive prep name
+    Current,
+
+    /// Show dive prep content
+    Show {
+        /// Name of prep to show (default: current)
+        name: Option<String>,
+    },
+
+    /// Load a dive pack from OH
     Load {
         /// Dive pack ID to load
         pack_id: String,
+
+        /// Save as named prep instead of dive_context.md
+        #[arg(long)]
+        name: Option<String>,
     },
 
-    /// Clear the current OH context
+    /// Clear the current dive context
     Clear,
-
-    /// Show current OH context
-    Show,
 }
 
 #[derive(Subcommand)]
@@ -171,9 +208,15 @@ fn main() -> ExitCode {
         }),
         Commands::Show { what, session_id } => show::run(&what, session_id.as_deref()),
         Commands::Dive { command } => match command {
-            DiveCommands::Load { pack_id } => dive::load(&pack_id),
+            DiveCommands::List => dive::list(),
+            DiveCommands::New { name } => dive::new(&name, None),
+            DiveCommands::Switch { name } => dive::switch(&name),
+            DiveCommands::Delete { name } => dive::delete(&name),
+            DiveCommands::Save { name } => dive::save(&name),
+            DiveCommands::Current => dive::current(),
+            DiveCommands::Show { name } => dive::show(name.as_deref()),
+            DiveCommands::Load { pack_id, name } => dive::load(&pack_id, name.as_deref()),
             DiveCommands::Clear => dive::clear(),
-            DiveCommands::Show => dive::show(),
         },
         Commands::Pause { operation } => run_pause(operation),
         Commands::Resume { operation } => run_resume(operation),

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,6 +27,16 @@ pub struct HookResponse {
 pub struct Config {
     #[serde(default)]
     pub operations: OperationsConfig,
+
+    #[serde(default)]
+    pub dive: DiveConfig,
+}
+
+/// Configuration for named dive preps
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DiveConfig {
+    /// Name of the currently active dive prep (None = use legacy dive_context.md)
+    pub current: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -46,6 +56,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             operations: OperationsConfig::default(),
+            dive: DiveConfig::default(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add support for multiple named dive preps that work like git branches
- New CLI commands: `list`, `new`, `switch`, `delete`, `save`, `current`, `show`
- Named preps stored in `.wm/dives/{name}.md` with current tracked in config
- Compile hook reads from current prep with fallback to legacy `dive_context.md`

## CLI Reference
```
wm dive list              # List all preps (* marks current)
wm dive new <name>        # Create new prep
wm dive switch <name>     # Switch to a prep
wm dive delete <name>     # Delete a prep
wm dive save <name>       # Save current dive_context.md as named prep
wm dive current           # Show current prep name
wm dive show [name]       # Show prep content
```

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (22 tests)
- [x] Manual test: create, list, switch, show, delete preps
- [x] Backwards compatible: legacy `dive_context.md` still works as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added named dive prep management system with commands to list, create, switch between, delete, save, and display preparation contexts
- Enhanced load command to optionally save loaded content as a named prep

**Documentation**
- Added guidance on managing named dive preps via the CLI

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->