### PR TITLE
Add Claude Code commands for slash command support

### DIFF
--- a/plugin/commands/compress.md
+++ b/plugin/commands/compress.md
@@ -1,0 +1,19 @@
+# /wm:compress
+
+Compress and synthesize working memory state.
+
+## Usage
+
+```
+/wm:compress
+```
+
+## Execution
+
+Run the wm compress command:
+
+```bash
+wm compress
+```
+
+Pass through the output. This abstracts accumulated knowledge to higher-level patterns, reducing size while preserving critical insights.

--- a/plugin/commands/distill.md
+++ b/plugin/commands/distill.md
@@ -1,0 +1,19 @@
+# /wm:distill
+
+Extract tacit knowledge from recent work into working memory.
+
+## Usage
+
+```
+/wm:distill
+```
+
+## Execution
+
+Run the wm distill command:
+
+```bash
+wm distill
+```
+
+Pass through the output. This extracts learnings from recent sessions and adds them to `.wm/state.md`.

--- a/plugin/commands/dive-prep.md
+++ b/plugin/commands/dive-prep.md
@@ -1,0 +1,25 @@
+# /wm:dive-prep
+
+Prepare working memory context for a focused session.
+
+## Usage
+
+```
+/wm:dive-prep [intent]
+```
+
+## Execution
+
+Run the wm dive-prep command:
+
+```bash
+wm dive-prep
+```
+
+If an intent is provided, pass it along:
+
+```bash
+wm dive-prep --intent "<intent>"
+```
+
+Pass through the output to the user. The command reads `.wm/state.md` and surfaces relevant context for the session.

--- a/plugin/commands/init.md
+++ b/plugin/commands/init.md
@@ -1,0 +1,36 @@
+# /wm:init
+
+Initialize working memory in the current project.
+
+## Usage
+
+```
+/wm:init
+```
+
+## Execution
+
+1. Check if wm binary exists:
+   ```bash
+   command -v wm
+   ```
+
+2. If wm not found, tell the user to install it:
+   ```
+   The wm CLI is not installed.
+
+   Install with Homebrew:
+     brew install open-horizon-labs/homebrew-tap/wm
+
+   Or with Cargo:
+     cargo install working-memory
+
+   Then run this command again.
+   ```
+
+3. If wm exists, run:
+   ```bash
+   wm init
+   ```
+
+   This creates `.wm/` directory with initial state.

--- a/plugin/commands/pause.md
+++ b/plugin/commands/pause.md
@@ -1,0 +1,19 @@
+# /wm:pause
+
+Capture session state for later resumption.
+
+## Usage
+
+```
+/wm:pause
+```
+
+## Execution
+
+Run the wm pause command:
+
+```bash
+wm pause
+```
+
+Pass through the output. This saves current session context to `.wm/` for later resumption.

--- a/plugin/commands/review.md
+++ b/plugin/commands/review.md
@@ -1,0 +1,19 @@
+# /wm:review
+
+Review current working memory state.
+
+## Usage
+
+```
+/wm:review
+```
+
+## Execution
+
+Run the wm review command or read the state directly:
+
+```bash
+wm review
+```
+
+Or if `wm review` doesn't exist, read and display `.wm/state.md` to show the current working memory contents.


### PR DESCRIPTION
## Summary

Claude Code requires commands in `plugin/commands/` for slash commands to work. The existing `agents/` folder contains the agent definitions but wasn't being exposed as `/wm:*` commands.

## Changes

Added `plugin/commands/` folder with command wrappers:
- `/wm:init` - Initialize working memory
- `/wm:dive-prep` - Prepare context for focused session
- `/wm:distill` - Extract learnings from recent work
- `/wm:compress` - Synthesize and compress state
- `/wm:pause` - Capture session state
- `/wm:review` - Review current working memory

Each command is a thin wrapper that invokes the corresponding `wm` CLI command.

## Test plan

- [ ] Install plugin from bottle marketplace after sync
- [ ] Verify `/wm:dive-prep` command is available in Claude Code
- [ ] Test each command works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)