### PR TITLE
feat: add `wm dive prep` CLI command for session scaffolding

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,17 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum DiveCommands {
+    /// Prepare a dive session from local context and optional intent
+    Prep {
+        /// Intent for the session (GitHub issue URL, description, etc.)
+        #[arg(long)]
+        intent: Option<String>,
+
+        /// Intent type: fix, plan, review, explore, ship
+        #[arg(long, default_value = "explore")]
+        intent_type: String,
+    },
+
     /// List all dive preps (marks current with *)
     List,
 
@@ -215,6 +226,10 @@ fn main() -> ExitCode {
         }),
         Commands::Show { what, session_id } => show::run(&what, session_id.as_deref()),
         Commands::Dive { command } => match command {
+            DiveCommands::Prep {
+                intent,
+                intent_type,
+            } => dive::prep(intent.as_deref(), &intent_type),
             DiveCommands::List => dive::list(),
             DiveCommands::New { name } => dive::new(&name, None),
             DiveCommands::Switch { name } => dive::switch(&name),


### PR DESCRIPTION
## Summary

- Add `wm dive prep` CLI subcommand for non-interactive session scaffolding
- Detect GitHub issue URLs and fetch title/body via `gh` CLI
- Gather local context (CLAUDE.md, git state) automatically
- Support intent types: fix, plan, review, explore, ship

## Usage

```bash
# With GitHub issue
wm dive prep --intent "https://github.com/org/repo/issues/123" --intent-type fix

# With plain text
wm dive prep --intent "Implement feature X" --intent-type plan

# Default explore
wm dive prep
```

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` passes (33 tests)
- [x] `cargo clippy` clean
- [x] Tested with real GitHub issue URL

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added a `prep` command that scaffolds dive context files by automatically integrating project documentation, git repository state, and intent-specific workflow guidance. Supports optional intent description and configurable intent types to customize the generated context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->