### PR TITLE
Add OpenCode skills support

### DIFF
--- a/.opencode/skills/wm-dive-prep/SKILL.md
+++ b/.opencode/skills/wm-dive-prep/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: dive-prep
+description: Prepare a grounded dive session with context from multiple sources
+---
+
+# Dive Prep
+
+Prepare working memory context for a focused session by gathering context from multiple sources.
+
+## Invocation
+
+`/wm:dive-prep [intent or context]`
+
+## Execution
+
+**DO NOT run any bash command.** This skill requires an AI agent.
+
+Use the Task tool to spawn the wm:dive-prep agent:
+
+```
+Task(subagent_type: "wm:dive-prep", prompt: "<user's intent or context>")
+```
+
+If the user provides a GitHub issue URL, include it in the prompt:
+```
+Task(subagent_type: "wm:dive-prep", prompt: "Prepare dive for https://github.com/org/repo/issues/123")
+```
+
+## What the Agent Does
+
+1. Detect OH connection and suggest linking endeavors
+2. Gather local context (CLAUDE.md, git state, etc.)
+3. Fetch OH context if available
+4. Write `.wm/dive_context.md` with curated grounding
+
+## Output
+
+Pass through the agent's output to the user. The dive context will be saved to `.wm/dive_context.md`.
+
+## Example
+
+```
+User: /wm:dive-prep fix the auth bug in the login flow
+
+Action: Task(subagent_type: "wm:dive-prep", prompt: "fix the auth bug in the login flow")
+```

--- a/.opencode/skills/wm/SKILL.md
+++ b/.opencode/skills/wm/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: wm
+description: Working Memory for AI coding assistants. Captures tacit knowledge from sessions and surfaces relevant context. Use "wm show" to review state, "wm compress" to synthesize.
+license: Apache 2.0
+---
+
+# wm — Working Memory for AI Coding Assistants
+
+wm automatically captures tacit knowledge from your coding sessions and surfaces relevant context for each new task. It's the memory layer that helps AI assistants learn how *you* work.
+
+## Commands
+
+### wm show [what]
+
+Review current working memory state.
+
+```bash
+wm show           # Show state.md (default)
+wm show state     # Show .wm/state.md
+wm show working   # Show compiled working set
+wm show sessions  # List available sessions
+```
+
+**Use this to:** Check what wm has captured before starting work.
+
+### wm compress
+
+Compress and synthesize working memory state.
+
+```bash
+wm compress
+```
+
+Abstracts accumulated knowledge to higher-level patterns, reducing size while preserving critical insights.
+
+**Use this when:** State.md is getting too large or redundant.
+
+### wm distill
+
+Batch extract tacit knowledge from all sessions in this project.
+
+```bash
+wm distill
+```
+
+Processes all sessions and extracts:
+- Metis (wisdom patterns)
+- Guardrails (constraints discovered)
+
+**Use this when:** Setting up a new project or after many sessions.
+
+### wm pause [extract|compile|both]
+
+Pause or resume wm operations.
+
+```bash
+wm pause extract    # Pause extraction only
+wm pause compile    # Pause compilation only
+wm pause both       # Pause all operations
+wm resume           # Resume operations
+```
+
+**Use this when:** You want to work without wm capturing/injecting context.
+
+### wm init
+
+Initialize wm in a project.
+
+```bash
+wm init
+```
+
+Creates `.wm/` directory structure:
+- `state.md` - Current session state
+- `distill/` - Extracted patterns
+- `sessions/` - Session archives
+
+**Use this when:** Starting a new project.
+
+## Dive Prep (Agent-based)
+
+For complex context gathering, use the dive-prep agent:
+
+```
+/wm:dive-prep [intent or context]
+```
+
+This spawns an agent that:
+1. Detects OH connection and suggests linking endeavors
+2. Gathers local context (CLAUDE.md, git state, etc.)
+3. Fetches OH context if available
+4. Writes `.wm/dive_context.md` with curated grounding
+
+## What Gets Captured
+
+**Tacit knowledge** is the unspoken wisdom in how someone works:
+
+- Rationale behind decisions (WHY this approach)
+- Paths rejected and why (judgment in pruning options)
+- Constraints discovered through friction
+- Preferences revealed by corrections
+- Patterns followed without stating
+
+**Not captured:**
+- What happened ("Fixed X", "Updated Y")
+- Explicit requests or questions
+- Tool outputs or code snippets
+
+## Storage
+
+Working memory stored in `.wm/`:
+```
+.wm/
+├── state.md          # Current session state
+├── dive_context.md   # Prepared dive context
+├── distill/
+│   ├── metis.md      # Wisdom patterns
+│   └── guardrails.md # Constraints
+└── sessions/         # Archived sessions
+```
+
+## Quick Reference
+
+```text
+wm show               # Review current state
+wm compress           # Synthesize state
+wm distill            # Extract from all sessions
+wm pause extract      # Pause extraction
+wm resume             # Resume operations
+wm init               # Initialize in project
+```


### PR DESCRIPTION
## Summary
- Adds `.opencode/skills/wm/SKILL.md` - comprehensive wm skill covering all commands
- Adds `.opencode/skills/wm-dive-prep/SKILL.md` - agent-based dive prep skill
- OpenCode's `/skills` command will now list wm skills

## Skills Added

| Skill | Description |
|-------|-------------|
| wm | Main skill with show, compress, distill, pause commands |
| wm-dive-prep | Agent-based context gathering for dive sessions |

## Why file-based?

For documentation and discovery, file-based is simpler:
- No npm dependency
- Native OpenCode discovery
- Matches Claude Code plugin structure

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the Working Memory skill, including available commands (show, compress, distill, pause, init), usage instructions, and storage layout.
  * Added documentation for the Dive Prep skill detailing its invocation syntax and execution model.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->