### PR TITLE
feat: add comprehensive release workflow with plan pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,11 @@ jobs:
   #   build:all    - Build everything
   #   build-me     - Trigger build (required for labeled events)
   #
+  # IMPORTANT: The 'build-me' label MUST be added to trigger builds. Adding only
+  # 'build:macos' or 'build:linux' will not work - those labels specify WHAT to
+  # build, while 'build-me' is the trigger. This prevents accidental builds when
+  # organizing labels.
+  #
   plan:
     name: Plan
     runs-on: ubuntu-latest
@@ -188,6 +193,9 @@ jobs:
           tar -czvf wm-${{ needs.plan.outputs.version }}-${{ matrix.target }}.tar.gz wm
           shasum -a 256 wm-${{ needs.plan.outputs.version }}-${{ matrix.target }}.tar.gz > wm-${{ needs.plan.outputs.version }}-${{ matrix.target }}.tar.gz.sha256
 
+      - name: Verify binary
+        run: ./dist/wm --version
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -238,11 +246,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/cargo-zigbuild
-          key: cargo-zigbuild-0.20
+          key: cargo-zigbuild-0.21.1
 
       - name: Install cargo-zigbuild
         if: steps.cache-zigbuild.outputs.cache-hit != 'true'
-        run: cargo install cargo-zigbuild --locked
+        run: cargo install cargo-zigbuild --locked --version 0.21.1
 
       - name: Build with zigbuild
         run: cargo zigbuild --release --target ${{ matrix.target }}
@@ -254,6 +262,9 @@ jobs:
           cd dist
           tar -czvf wm-${{ needs.plan.outputs.version }}-${{ matrix.target }}.tar.gz wm
           sha256sum wm-${{ needs.plan.outputs.version }}-${{ matrix.target }}.tar.gz > wm-${{ needs.plan.outputs.version }}-${{ matrix.target }}.tar.gz.sha256
+
+      - name: Verify binary
+        run: ./dist/wm --version
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -388,6 +399,7 @@ jobs:
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        # --allow-dirty is needed because we modify Cargo.toml version in CI
         run: cargo publish --allow-dirty
 
   # =============================================================================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
           LABEL_ADDED: ${{ github.event.label.name }}
+          HAS_LABEL_BUILD_ME: ${{ contains(github.event.pull_request.labels.*.name, 'build-me') }}
           HAS_LABEL_ALL: ${{ contains(github.event.pull_request.labels.*.name, 'build:all') }}
           HAS_LABEL_MACOS: ${{ contains(github.event.pull_request.labels.*.name, 'build:macos') }}
           HAS_LABEL_LINUX: ${{ contains(github.event.pull_request.labels.*.name, 'build:linux') }}
@@ -94,6 +95,17 @@ jobs:
           # Skip if triggered by a non-build label (only 'build-me' triggers builds)
           if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_ADDED" != "build-me" ]]; then
             echo "::notice::Skipping: labeled event for '$LABEL_ADDED' (only 'build-me' triggers builds)"
+            echo "should_skip=true" >> $GITHUB_OUTPUT
+            echo "is_release=false" >> $GITHUB_OUTPUT
+            echo "is_dry_run=true" >> $GITHUB_OUTPUT
+            echo "build_macos=false" >> $GITHUB_OUTPUT
+            echo "build_linux=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # For PR events (opened/synchronize/reopened), require 'build-me' label
+          if [[ "$EVENT_NAME" == "pull_request" && "$HAS_LABEL_BUILD_ME" != "true" ]]; then
+            echo "::notice::Skipping: PR does not have 'build-me' label"
             echo "should_skip=true" >> $GITHUB_OUTPUT
             echo "is_release=false" >> $GITHUB_OUTPUT
             echo "is_dry_run=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,36 +1,407 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (skip publishing)'
+        type: boolean
+        default: false
+      build_macos:
+        description: 'Build macOS binaries'
+        type: boolean
+        default: false
+      build_linux:
+        description: 'Build Linux binaries'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  publish-crates:
-    name: Publish to crates.io
+  # =============================================================================
+  # PLAN: Centralized decision logic
+  # =============================================================================
+  # This job runs first (~5s) and computes which builds are needed.
+  # All other jobs check plan outputs instead of duplicating condition logic.
+  #
+  # Labels (for PRs):
+  #   build:macos  - Build macOS binaries
+  #   build:linux  - Build Linux binaries
+  #   build:all    - Build everything
+  #   build-me     - Trigger build (required for labeled events)
+  #
+  plan:
+    name: Plan
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      git_sha: ${{ steps.version.outputs.git_sha }}
+      is_release: ${{ steps.decide.outputs.is_release }}
+      is_dry_run: ${{ steps.decide.outputs.is_dry_run }}
+      build_macos: ${{ steps.decide.outputs.build_macos }}
+      build_linux: ${{ steps.decide.outputs.build_linux }}
+      should_skip: ${{ steps.decide.outputs.should_skip }}
+    steps:
+      - name: Compute version
+        id: version
+        run: |
+          # Version from tag (strip 'v' prefix)
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            VERSION="0.0.0-pr${{ github.event.pull_request.number }}"
+          else
+            VERSION="0.0.0-dev"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Git SHA (short)
+          GIT_SHA="${GITHUB_SHA:0:7}"
+          echo "git_sha=$GIT_SHA" >> $GITHUB_OUTPUT
+
+          echo "::notice::Build version: $VERSION ($GIT_SHA)"
+
+      - name: Decide what to build
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_ADDED: ${{ github.event.label.name }}
+          HAS_LABEL_ALL: ${{ contains(github.event.pull_request.labels.*.name, 'build:all') }}
+          HAS_LABEL_MACOS: ${{ contains(github.event.pull_request.labels.*.name, 'build:macos') }}
+          HAS_LABEL_LINUX: ${{ contains(github.event.pull_request.labels.*.name, 'build:linux') }}
+          INPUT_MACOS: ${{ inputs.build_macos }}
+          INPUT_LINUX: ${{ inputs.build_linux }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          # Skip if triggered by a non-build label (only 'build-me' triggers builds)
+          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_ADDED" != "build-me" ]]; then
+            echo "::notice::Skipping: labeled event for '$LABEL_ADDED' (only 'build-me' triggers builds)"
+            echo "should_skip=true" >> $GITHUB_OUTPUT
+            echo "is_release=false" >> $GITHUB_OUTPUT
+            echo "is_dry_run=true" >> $GITHUB_OUTPUT
+            echo "build_macos=false" >> $GITHUB_OUTPUT
+            echo "build_linux=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "should_skip=false" >> $GITHUB_OUTPUT
+
+          # Is this a release?
+          IS_RELEASE=$([[ "$EVENT_NAME" == "push" && "${{ github.ref_type }}" == "tag" ]] && echo "true" || echo "false")
+          echo "is_release=$IS_RELEASE" >> $GITHUB_OUTPUT
+
+          # Dry run? (PRs are always dry run, workflow_dispatch can override)
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            IS_DRY_RUN="true"
+          elif [[ "$INPUT_DRY_RUN" == "true" ]]; then
+            IS_DRY_RUN="true"
+          else
+            IS_DRY_RUN="false"
+          fi
+          echo "is_dry_run=$IS_DRY_RUN" >> $GITHUB_OUTPUT
+
+          # Helper: should we build everything?
+          should_build_all() {
+            [[ "$IS_RELEASE" == "true" ]] && return 0
+            [[ "$HAS_LABEL_ALL" == "true" ]] && return 0
+            return 1
+          }
+
+          # macOS builds
+          BUILD_MACOS="false"
+          if should_build_all; then BUILD_MACOS="true"; fi
+          if [[ "$HAS_LABEL_MACOS" == "true" ]]; then BUILD_MACOS="true"; fi
+          if [[ "$INPUT_MACOS" == "true" ]]; then BUILD_MACOS="true"; fi
+          echo "build_macos=$BUILD_MACOS" >> $GITHUB_OUTPUT
+
+          # Linux builds
+          BUILD_LINUX="false"
+          if should_build_all; then BUILD_LINUX="true"; fi
+          if [[ "$HAS_LABEL_LINUX" == "true" ]]; then BUILD_LINUX="true"; fi
+          if [[ "$INPUT_LINUX" == "true" ]]; then BUILD_LINUX="true"; fi
+          echo "build_linux=$BUILD_LINUX" >> $GITHUB_OUTPUT
+
+          # Summary
+          echo "### Build Plan" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Setting | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Release | $IS_RELEASE |" >> $GITHUB_STEP_SUMMARY
+          echo "| Dry Run | $IS_DRY_RUN |" >> $GITHUB_STEP_SUMMARY
+          echo "| macOS | $BUILD_MACOS |" >> $GITHUB_STEP_SUMMARY
+          echo "| Linux | $BUILD_LINUX |" >> $GITHUB_STEP_SUMMARY
+
+  # =============================================================================
+  # BUILD: macOS targets (native)
+  # =============================================================================
+  build-macos:
+    name: Build macOS (${{ matrix.arch }})
+    needs: plan
+    if: needs.plan.outputs.build_macos == 'true' && needs.plan.outputs.should_skip != 'true'
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            arch: arm64
+          - target: x86_64-apple-darwin
+            arch: x64
     steps:
       - uses: actions/checkout@v4
 
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+      - name: Set version in Cargo.toml
+        run: |
+          VERSION="${{ needs.plan.outputs.version }}"
+          perl -i -pe "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
 
-      - name: Update Cargo.toml version
-        run: sed -i 's/^version = ".*"/version = "${{ steps.version.outputs.VERSION }}"/' Cargo.toml
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v2
+        with:
+          shared-key: macos-${{ matrix.target }}
+          save-if: ${{ needs.plan.outputs.is_release == 'true' }}
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package binary
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/wm dist/
+          cd dist
+          tar -czvf wm-${{ needs.plan.outputs.version }}-${{ matrix.target }}.tar.gz wm
+          shasum -a 256 wm-${{ needs.plan.outputs.version }}-${{ matrix.target }}.tar.gz > wm-${{ needs.plan.outputs.version }}-${{ matrix.target }}.tar.gz.sha256
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wm-${{ matrix.target }}
+          path: dist/wm-${{ needs.plan.outputs.version }}-${{ matrix.target }}.*
+
+  # =============================================================================
+  # BUILD: Linux targets (zigbuild for cross-compilation)
+  # =============================================================================
+  build-linux:
+    name: Build Linux (${{ matrix.arch }})
+    needs: plan
+    if: needs.plan.outputs.build_linux == 'true' && needs.plan.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            arch: x64
+          - target: aarch64-unknown-linux-musl
+            arch: arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set version in Cargo.toml
+        run: |
+          VERSION="${{ needs.plan.outputs.version }}"
+          perl -i -pe "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          shared-key: zigbuild-${{ matrix.target }}
+          save-if: ${{ needs.plan.outputs.is_release == 'true' }}
+
+      - name: Install zig
+        run: |
+          curl -L https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz | tar -xJ
+          sudo mv zig-linux-x86_64-0.13.0 /opt/zig
+          echo "/opt/zig" >> $GITHUB_PATH
+
+      - name: Cache cargo-zigbuild
+        id: cache-zigbuild
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-zigbuild
+          key: cargo-zigbuild-0.20
+
+      - name: Install cargo-zigbuild
+        if: steps.cache-zigbuild.outputs.cache-hit != 'true'
+        run: cargo install cargo-zigbuild --locked
+
+      - name: Build with zigbuild
+        run: cargo zigbuild --release --target ${{ matrix.target }}
+
+      - name: Package binary
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/wm dist/
+          cd dist
+          tar -czvf wm-${{ needs.plan.outputs.version }}-${{ matrix.target }}.tar.gz wm
+          sha256sum wm-${{ needs.plan.outputs.version }}-${{ matrix.target }}.tar.gz > wm-${{ needs.plan.outputs.version }}-${{ matrix.target }}.tar.gz.sha256
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wm-${{ matrix.target }}
+          path: dist/wm-${{ needs.plan.outputs.version }}-${{ matrix.target }}.*
+
+  # =============================================================================
+  # RELEASE: Create GitHub release and upload artifacts
+  # =============================================================================
+  release:
+    name: Release
+    needs: [plan, build-macos, build-linux]
+    runs-on: ubuntu-latest
+    if: needs.plan.outputs.is_release == 'true' && needs.plan.outputs.is_dry_run != 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -la artifacts/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ needs.plan.outputs.version }}" \
+            --title "v${{ needs.plan.outputs.version }}" \
+            --generate-notes \
+            artifacts/*
+
+  # =============================================================================
+  # PUBLISH: Homebrew tap
+  # =============================================================================
+  publish-homebrew:
+    name: Publish Homebrew
+    needs: [plan, release]
+    runs-on: ubuntu-latest
+    if: needs.plan.outputs.is_release == 'true' && needs.plan.outputs.is_dry_run != 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: open-horizon-labs/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Download artifacts for checksums
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Update Homebrew formula
+        run: |
+          VERSION="${{ needs.plan.outputs.version }}"
+          ARM64_MAC_SHA=$(cat artifacts/wm-${VERSION}-aarch64-apple-darwin.tar.gz.sha256 | awk '{print $1}')
+          X64_MAC_SHA=$(cat artifacts/wm-${VERSION}-x86_64-apple-darwin.tar.gz.sha256 | awk '{print $1}')
+          X64_LINUX_SHA=$(cat artifacts/wm-${VERSION}-x86_64-unknown-linux-musl.tar.gz.sha256 | awk '{print $1}')
+          ARM64_LINUX_SHA=$(cat artifacts/wm-${VERSION}-aarch64-unknown-linux-musl.tar.gz.sha256 | awk '{print $1}')
+
+          cat > homebrew-tap/Formula/wm.rb << EOF
+          class Wm < Formula
+            desc "Working memory for AI coding assistants"
+            homepage "https://github.com/open-horizon-labs/wm"
+            version "${VERSION}"
+            license "LicenseRef-Proprietary"
+
+            on_macos do
+              if Hardware::CPU.arm?
+                url "https://github.com/open-horizon-labs/wm/releases/download/v${VERSION}/wm-${VERSION}-aarch64-apple-darwin.tar.gz"
+                sha256 "${ARM64_MAC_SHA}"
+              else
+                url "https://github.com/open-horizon-labs/wm/releases/download/v${VERSION}/wm-${VERSION}-x86_64-apple-darwin.tar.gz"
+                sha256 "${X64_MAC_SHA}"
+              end
+            end
+
+            on_linux do
+              if Hardware::CPU.arm?
+                url "https://github.com/open-horizon-labs/wm/releases/download/v${VERSION}/wm-${VERSION}-aarch64-unknown-linux-musl.tar.gz"
+                sha256 "${ARM64_LINUX_SHA}"
+              else
+                url "https://github.com/open-horizon-labs/wm/releases/download/v${VERSION}/wm-${VERSION}-x86_64-unknown-linux-musl.tar.gz"
+                sha256 "${X64_LINUX_SHA}"
+              end
+            end
+
+            def install
+              bin.install "wm"
+            end
+
+            test do
+              system "#{bin}/wm", "--version"
+            end
+          end
+          EOF
+
+      - name: Commit and push
+        run: |
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/wm.rb
+          git commit -m "wm ${{ needs.plan.outputs.version }}"
+          git push
+
+  # =============================================================================
+  # PUBLISH: crates.io
+  # =============================================================================
+  publish-crates:
+    name: Publish crates.io
+    needs: [plan, release]
+    runs-on: ubuntu-latest
+    if: needs.plan.outputs.is_release == 'true' && needs.plan.outputs.is_dry_run != 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set version in Cargo.toml
+        run: |
+          VERSION="${{ needs.plan.outputs.version }}"
+          perl -i -pe "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: swatinem/rust-cache@v2
 
       - name: Publish to crates.io
-        run: cargo publish --allow-dirty --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --allow-dirty
 
+  # =============================================================================
+  # PUBLISH: npm (opencode plugin)
+  # =============================================================================
   publish-npm:
-    name: Publish to npm
+    name: Publish npm
+    needs: [plan, release]
     runs-on: ubuntu-latest
     environment: npm
     permissions:
       contents: read
       id-token: write
+    if: needs.plan.outputs.is_release == 'true' && needs.plan.outputs.is_dry_run != 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -46,14 +417,10 @@ jobs:
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@latest
 
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
-
       - name: Update package.json version
         working-directory: opencode-plugin
         run: |
-          jq --arg v "${{ steps.version.outputs.VERSION }}" '.version = $v' package.json > package.json.tmp
+          jq --arg v "${{ needs.plan.outputs.version }}" '.version = $v' package.json > package.json.tmp
           mv package.json.tmp package.json
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Add centralized plan job for build decisions (matching bottle's pattern)
- Add macOS build job (native arm64 + x64)
- Add Linux build job (zigbuild for musl targets)
- Add GitHub release with binary artifacts
- Add Homebrew tap publishing to open-horizon-labs/homebrew-tap
- Integrate existing crates.io and npm publishing into new structure

## Features

**Build triggers:**
- Tag push (`v*`) - Full release
- Pull request with labels (`build:macos`, `build:linux`, `build:all`, `build-me`)
- Manual workflow dispatch with dry_run option

**Artifacts produced:**
- `wm-VERSION-aarch64-apple-darwin.tar.gz` (macOS ARM64)
- `wm-VERSION-x86_64-apple-darwin.tar.gz` (macOS x64)
- `wm-VERSION-aarch64-unknown-linux-musl.tar.gz` (Linux ARM64)
- `wm-VERSION-x86_64-unknown-linux-musl.tar.gz` (Linux x64)

**Publishing targets:**
- GitHub Releases (binary artifacts)
- Homebrew tap (open-horizon-labs/homebrew-tap)
- crates.io (existing)
- npm (existing opencode plugin)

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Test with `build:macos` label on a PR
- [ ] Test with `build:linux` label on a PR
- [ ] Test full release with a version tag

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-platform build and packaging pipelines (macOS, Linux) with artifact hashing, uploads, and a centralized version used for release artifacts.
  * Automated publishing pipelines for Homebrew, crates.io, and npm, using the centralized plan-derived version and generated release notes.

* **Chores**
  * Centralized release decision and version derivation, improved triggers, concurrency controls, and conditional run/skip behavior for clearer orchestration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->