### PR TITLE
refactor: extract system_time_to_datetime to shared types

### DIFF
--- a/src/codex/session.rs
+++ b/src/codex/session.rs
@@ -8,9 +8,9 @@ use chrono::{DateTime, Utc};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
 
 use crate::codex::types::CodexEntry;
+use crate::types::system_time_to_datetime;
 
 /// Information about a discovered Codex session
 #[derive(Debug, Clone)]
@@ -173,12 +173,6 @@ fn read_dir_sorted(path: &Path) -> Result<Vec<std::fs::DirEntry>, String> {
 
     entries.sort_by_key(|e| e.path());
     Ok(entries)
-}
-
-/// Convert SystemTime to DateTime<Utc>
-fn system_time_to_datetime(st: SystemTime) -> Option<DateTime<Utc>> {
-    let duration = st.duration_since(std::time::UNIX_EPOCH).ok()?;
-    DateTime::from_timestamp(duration.as_secs() as i64, duration.subsec_nanos())
 }
 
 #[cfg(test)]

--- a/src/session.rs
+++ b/src/session.rs
@@ -8,7 +8,8 @@
 
 use chrono::{DateTime, Utc};
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+
+use crate::types::system_time_to_datetime;
 
 /// Information about a discovered session transcript
 #[derive(Debug, Clone)]
@@ -109,12 +110,6 @@ pub fn discover_sessions_in_dir(project_dir: &Path) -> Result<Vec<SessionInfo>, 
     sessions.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
 
     Ok(sessions)
-}
-
-/// Convert SystemTime to DateTime<Utc>
-fn system_time_to_datetime(st: SystemTime) -> Option<DateTime<Utc>> {
-    let duration = st.duration_since(std::time::UNIX_EPOCH).ok()?;
-    DateTime::from_timestamp(duration.as_secs() as i64, duration.subsec_nanos())
 }
 
 /// Get the current project path

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,16 @@
 //! Core data types for WM
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::time::SystemTime;
+
+/// Convert SystemTime to DateTime<Utc>
+///
+/// Shared utility used by session discovery in both Claude Code and Codex modules.
+pub fn system_time_to_datetime(st: SystemTime) -> Option<DateTime<Utc>> {
+    let duration = st.duration_since(std::time::UNIX_EPOCH).ok()?;
+    DateTime::from_timestamp(duration.as_secs() as i64, duration.subsec_nanos())
+}
 
 /// Hook-specific output for UserPromptSubmit hooks
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- Move identical `system_time_to_datetime` helper from both `session.rs` and `codex/session.rs` to `types.rs`
- First step in deduplication effort (Priority 1 from dive-prep analysis)

## Test plan
- [x] `cargo test` passes (33 tests)
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal utilities to reduce code duplication across the codebase, improving maintainability and consistency while preserving all existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->