### PR TITLE
refactor: consolidate duplicated code across modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "working-memory"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "clap",

--- a/src/codex/session.rs
+++ b/src/codex/session.rs
@@ -4,32 +4,14 @@
 //! Unlike Claude Code (which uses project-id directories), Codex sessions embed
 //! the cwd in session_meta, so we need to read each file to filter by project.
 
-use chrono::{DateTime, Utc};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 use crate::codex::types::CodexEntry;
+// Re-export CodexSessionInfo for backward compatibility
+pub use crate::types::CodexSessionInfo;
 use crate::types::system_time_to_datetime;
-
-/// Information about a discovered Codex session
-#[derive(Debug, Clone)]
-pub struct CodexSessionInfo {
-    /// Session ID (from session_meta or filename)
-    pub session_id: String,
-
-    /// Full path to the session JSONL file
-    pub session_path: PathBuf,
-
-    /// Working directory where the session ran
-    pub cwd: Option<String>,
-
-    /// Last modification time
-    pub modified_at: DateTime<Utc>,
-
-    /// File size in bytes
-    pub size_bytes: u64,
-}
 
 /// Get the Codex sessions root directory (~/.codex/sessions/)
 pub fn codex_sessions_dir() -> Option<PathBuf> {

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,26 +6,11 @@
 //! AIDEV-NOTE: This module is foundational for the distill command which needs to process
 //! all sessions in batch. Used by yz-yb9q (distill CLI).
 
-use chrono::{DateTime, Utc};
 use std::path::{Path, PathBuf};
 
+// Re-export SessionInfo for backward compatibility
+pub use crate::types::SessionInfo;
 use crate::types::system_time_to_datetime;
-
-/// Information about a discovered session transcript
-#[derive(Debug, Clone)]
-pub struct SessionInfo {
-    /// Session UUID (filename without .jsonl extension)
-    pub session_id: String,
-
-    /// Full path to the transcript file
-    pub transcript_path: PathBuf,
-
-    /// Last modification time
-    pub modified_at: DateTime<Utc>,
-
-    /// File size in bytes
-    pub size_bytes: u64,
-}
 
 /// Compute project-id from a project path
 /// Converts absolute path to Claude's project-id format: slashes become dashes

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,12 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use std::time::SystemTime;
+
+// =============================================================================
+// Shared Utilities
+// =============================================================================
 
 /// Convert SystemTime to DateTime<Utc>
 ///
@@ -10,6 +15,82 @@ use std::time::SystemTime;
 pub fn system_time_to_datetime(st: SystemTime) -> Option<DateTime<Utc>> {
     let duration = st.duration_since(std::time::UNIX_EPOCH).ok()?;
     DateTime::from_timestamp(duration.as_secs() as i64, duration.subsec_nanos())
+}
+
+/// Strip all occurrences of an XML-style tag from text
+///
+/// Used by both transcript readers to strip context/reminder tags.
+/// Example: `strip_xml_tags(text, "<system-reminder>", "</system-reminder>")`
+pub fn strip_xml_tags(text: &str, open_tag: &str, close_tag: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut search_start = 0;
+
+    while let Some(open_offset) = text[search_start..].find(open_tag) {
+        let open_pos = search_start + open_offset;
+        result.push_str(&text[search_start..open_pos]);
+
+        let after_open = open_pos + open_tag.len();
+        if let Some(close_offset) = text[after_open..].find(close_tag) {
+            search_start = after_open + close_offset + close_tag.len();
+        } else {
+            search_start = text.len();
+            break;
+        }
+    }
+
+    result.push_str(&text[search_start..]);
+    result.trim().to_string()
+}
+
+// =============================================================================
+// Shared Error Type
+// =============================================================================
+
+/// Unified error type for transcript/session reading
+///
+/// Replaces both TranscriptError and CodexReadError.
+#[derive(Debug)]
+pub enum ReadError {
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for ReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReadError::Io(e) => write!(f, "IO error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for ReadError {}
+
+impl From<std::io::Error> for ReadError {
+    fn from(e: std::io::Error) -> Self {
+        ReadError::Io(e)
+    }
+}
+
+// =============================================================================
+// Session Types
+// =============================================================================
+
+/// Claude Code session info
+#[derive(Debug, Clone)]
+pub struct SessionInfo {
+    pub session_id: String,
+    pub transcript_path: PathBuf,
+    pub modified_at: DateTime<Utc>,
+    pub size_bytes: u64,
+}
+
+/// Codex session info
+#[derive(Debug, Clone)]
+pub struct CodexSessionInfo {
+    pub session_id: String,
+    pub session_path: PathBuf,
+    pub cwd: Option<String>,
+    pub modified_at: DateTime<Utc>,
+    pub size_bytes: u64,
 }
 
 /// Hook-specific output for UserPromptSubmit hooks


### PR DESCRIPTION
## Summary
- Add unified `ReadError` type (replaces `TranscriptError` and `CodexReadError`)
- Add `strip_xml_tags()` shared utility (used by both tag stripping functions)
- Move `SessionInfo` and `CodexSessionInfo` structs to types.rs
- Re-export session types for backward compatibility

## Changes
| File | Change |
|------|--------|
| `types.rs` | +ReadError, +strip_xml_tags, +SessionInfo, +CodexSessionInfo |
| `transcript/reader.rs` | Use shared ReadError and strip_xml_tags |
| `codex/reader.rs` | Use shared ReadError and strip_xml_tags |
| `session.rs` | Re-export SessionInfo from types.rs |
| `codex/session.rs` | Re-export CodexSessionInfo from types.rs |

## Stats
- 92 additions, 131 deletions (net -39 lines)

## Test plan
- [x] `cargo test` - 33 tests pass
- [x] `cargo clippy` - no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of file parsing—malformed data lines are now skipped with warnings instead of causing failures.

* **Refactor**
  * Unified error handling across file readers for consistent behavior and messaging.
  * Consolidated shared data structures and utilities for better code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->