### PR TITLE
refactor: deduplicate distill.rs with SessionLike trait

### DIFF
--- a/src/codex/mod.rs
+++ b/src/codex/mod.rs
@@ -8,4 +8,4 @@ pub mod session;
 pub mod types;
 
 pub use reader::{format_context, read_codex_session};
-pub use session::{CodexSessionInfo, discover_sessions};
+pub use session::discover_sessions;

--- a/src/codex/session.rs
+++ b/src/codex/session.rs
@@ -9,9 +9,7 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 use crate::codex::types::CodexEntry;
-// Re-export CodexSessionInfo for backward compatibility
-pub use crate::types::CodexSessionInfo;
-use crate::types::system_time_to_datetime;
+use crate::types::{system_time_to_datetime, CodexSessionInfo};
 
 /// Get the Codex sessions root directory (~/.codex/sessions/)
 pub fn codex_sessions_dir() -> Option<PathBuf> {


### PR DESCRIPTION
## Summary
- Add `SessionLike` trait for generic session handling
- Replace 7 duplicated function pairs with generic implementations
- Extract shared helpers for common patterns

## Before/After

| Before | After |
|--------|-------|
| `run_pass1()` + `run_codex_pass1()` | `run_pass1_generic()` |
| `needs_extraction()` + `needs_codex_extraction()` | `needs_extraction<S: SessionLike>()` |
| `extract_from_session()` + `extract_from_codex_session()` | `extract_claude()` + `extract_codex()` (shared via `extract_from_formatted`) |
| `load_extraction_cache()` + `load_codex_extraction_cache()` | `load_cache(filename)` |
| `save_extraction_cache()` + `save_codex_extraction_cache()` | `save_cache(filename)` |
| `print_session_info_with_status()` + `print_codex_session_info_with_status()` | `SessionLike::display_info()` |

## Stats
- 175 additions, 271 deletions (net **-96 lines**)

## Test plan
- [x] `cargo test` - 33 tests pass
- [x] `cargo clippy` - no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified extraction pipeline to consistently handle different session types with a common interface.
  * Implemented separate cache files for Codex and Claude sessions for improved cache isolation.
  * Enhanced session identification and status checking with more reliable extraction logic.
  * Streamlined internal extraction workflow for better maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->